### PR TITLE
Make AVX symbols to be strictly visible (fix build with gcc8)

### DIFF
--- a/source/common/vec/intrinsic_cg_scan_avx.c
+++ b/source/common/vec/intrinsic_cg_scan_avx.c
@@ -35,14 +35,14 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-#include "../common.h"
-#include "intrinsic.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
+
+#include "../common.h"
+#include "intrinsic.h"
 
 #if ARCH_X86_64
 /* ---------------------------------------------------------------------------

--- a/source/common/vec/intrinsic_dct.c
+++ b/source/common/vec/intrinsic_dct.c
@@ -34,16 +34,15 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-#include "../basic_types.h"
-#include "../avs2_defs.h"
-#include "intrinsic.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
 
+#include "../basic_types.h"
+#include "../avs2_defs.h"
+#include "intrinsic.h"
 
 void *xavs2_fast_memzero_mmx(void *dst, size_t n);
 

--- a/source/common/vec/intrinsic_dct_avx.c
+++ b/source/common/vec/intrinsic_dct_avx.c
@@ -36,14 +36,14 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-#include "../basic_types.h"
-#include "intrinsic.h"
-#include "../avs2_defs.h"
-
 #include <xmmintrin.h>  // SSE
 #include <pmmintrin.h>  // SSE3
 #include <tmmintrin.h>  // SSSE3
 #include <immintrin.h>  // AVX and AVX2
+
+#include "../basic_types.h"
+#include "intrinsic.h"
+#include "../avs2_defs.h"
 
 /* disable warnings */
 #ifdef _MSC_VER

--- a/source/common/vec/intrinsic_deblock_avx2.c
+++ b/source/common/vec/intrinsic_deblock_avx2.c
@@ -34,15 +34,14 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-
-#include "../basic_types.h"
-#include "intrinsic.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
+
+#include "../basic_types.h"
+#include "intrinsic.h"
 
 void deblock_edge_ver_avx2(pel_t *SrcPtr, int stride, int Alpha, int Beta, uint8_t *flt_flag)
 {

--- a/source/common/vec/intrinsic_idct_avx2.c
+++ b/source/common/vec/intrinsic_idct_avx2.c
@@ -36,15 +36,15 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-#include "../basic_types.h"
-#include "../avs2_defs.h"
-#include "intrinsic.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
+
+#include "../basic_types.h"
+#include "../avs2_defs.h"
+#include "intrinsic.h"
 
 /* disable warnings */
 #pragma warning(disable:4127)  // warning C4127: 条件表达式是常量

--- a/source/common/vec/intrinsic_inter_pred.c
+++ b/source/common/vec/intrinsic_inter_pred.c
@@ -34,15 +34,15 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-#include "../basic_types.h"
-#include "intrinsic.h"
-#include "avs2_defs.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
+
+#include "../basic_types.h"
+#include "intrinsic.h"
+#include "avs2_defs.h"
 
 /* ---------------------------------------------------------------------------
  */

--- a/source/common/vec/intrinsic_inter_pred_avx2.c
+++ b/source/common/vec/intrinsic_inter_pred_avx2.c
@@ -34,14 +34,15 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-#include "../basic_types.h"
-#include "intrinsic.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
+
+#include "../basic_types.h"
+#include "intrinsic.h"
+
 #pragma warning(disable:4127)  // warning C4127: 条件表达式是常量
 
 /* ---------------------------------------------------------------------------

--- a/source/common/vec/intrinsic_intra-pred_avx2.c
+++ b/source/common/vec/intrinsic_intra-pred_avx2.c
@@ -34,16 +34,15 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-#include "../basic_types.h"
-#include "avs2_defs.h"
-#include "intrinsic.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
 
+#include "../basic_types.h"
+#include "avs2_defs.h"
+#include "intrinsic.h"
 
 #ifndef _MSC_VER
 #define __int64 int64_t

--- a/source/common/vec/intrinsic_pixel_avx.c
+++ b/source/common/vec/intrinsic_pixel_avx.c
@@ -34,16 +34,16 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-#include "../basic_types.h"
-#include "../avs2_defs.h"
-#include "intrinsic.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
 #include <string.h>
+
+#include "../basic_types.h"
+#include "../avs2_defs.h"
+#include "intrinsic.h"
 
 /* ---------------------------------------------------------------------------
  */

--- a/source/common/vec/intrinsic_quant_avx2.c
+++ b/source/common/vec/intrinsic_quant_avx2.c
@@ -35,15 +35,14 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-
-#include "../basic_types.h"
-#include "intrinsic.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
+
+#include "../basic_types.h"
+#include "intrinsic.h"
 
 int quant_c_avx2(coeff_t *coef, const int i_coef, const int scale, const int shift, const int add)
 {

--- a/source/common/vec/intrinsic_sao_avx2.c
+++ b/source/common/vec/intrinsic_sao_avx2.c
@@ -34,15 +34,15 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-#include "../common.h"
-#include "intrinsic.h"
-#include "../filter.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
+
+#include "../common.h"
+#include "intrinsic.h"
+#include "../filter.h"
 
 /* ---------------------------------------------------------------------------
  */


### PR DESCRIPTION
`_mm256_insertf128_si256` and `_mm256_castsi128_si256` are undeclared in the scope of `source/common/vec/intrinsic.h`, which seems to be strictly not permitted by gcc8.

Fixes #17