### PR TITLE
build/linux/Makefile: Fix the build error for x86inc

### DIFF
--- a/build/linux/Makefile
+++ b/build/linux/Makefile
@@ -89,9 +89,7 @@ X86SRC = common/x86/blockcopy8.asm \
 		common/x86/sad-a.asm \
 		common/x86/sad-vpp.asm \
 		common/x86/satd-a.asm \
-		common/x86/ssd-a.asm \
-		common/x86/x86inc.asm \
-		common/x86/x86util.asm 
+		common/x86/ssd-a.asm
 
 ifeq ($(SYS_ARCH),X86)
 ARCH_X86 = yes


### PR DESCRIPTION
don't need to add x86inc/x86utils to build list in Linux, else
will lead to error like:
"strip: error: the input file 'common/x86/x86util.o' has no sections
Makefile:245: recipe for target 'common/x86/x86util.o' failed
make: [common/x86/x86util.o] Error 1 (ignored)"

Signed-off-by: Jun Zhao <mypopydev@gmail.com>